### PR TITLE
Custom mode mappings so that emacs' mode: values can work

### DIFF
--- a/EmacsModelines.py
+++ b/EmacsModelines.py
@@ -15,6 +15,9 @@ MODELINE_MAX_LINES = 5
 
 
 class EmacsModelinesListener(sublime_plugin.EventListener):
+
+    settings = None
+
     def __init__(self):
         self._modes = {}
 
@@ -25,6 +28,13 @@ class EmacsModelinesListener(sublime_plugin.EventListener):
                     name = os.path.splitext(os.path.basename(f))[0].lower()
                     syntax_file = re.match(r'^.+/(Packages/.+)$', f).group(1)
                     self._modes[name] = syntax_file
+
+        # Load custom mappings from the settings file
+        self.settings = sublime.load_settings( __name__ + ".sublime-settings" )
+
+        if self.settings.has("mode_mappings"):
+            for modeline,syntax in self.settings.get("mode_mappings").items():
+             self._modes[modeline] = self._modes[syntax.lower()]
 
     def on_load(self, view):
         self.parse_modelines(view)

--- a/EmacsModelines.sublime-settings
+++ b/EmacsModelines.sublime-settings
@@ -1,0 +1,7 @@
+{
+
+  "mode_mappings" : {
+    "bash": "Shell-Unix-Generic"
+  }
+
+}

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,34 @@
+[
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "Emcas Modelines",
+                        "children":
+                        [
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/Emacs-like Modelines/EmacsModelines.sublime-settings"},
+                                "caption": "Settings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/EmacsModelines.sublime-settings"},
+                                "caption": "Settings – User"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ use:
 	view.settings().get('syntax')
 	# u'Packages/Graphviz/DOT.tmLanguage' -> 'DOT' is the mode value needed.
 
+If you want to use the same mode line settings with an emacs user you might need
+to set up mappings from the emacs names to the sublime syntax names. To do this
+look at the `mode_mappings` key in the settings file (which you can edit via the
+menu Preferences, Package Settings, Emacs Modelines). As an example this package
+ships with a mapping from "Bash" (emacs) to "Shell-Unix-Generic" (sublime).
+
 ## Alternatives
 
 * [Vim-style modelines](https://github.com/SublimeText/Modelines)


### PR DESCRIPTION
i.e. so that "bash" works to correctly set the syntax to "Shell-Unix-Generic"

Included docs and the settings file in the preferences menu like other PackageControl packages have
