### PR TITLE
Add support for *.sublime-syntax files.

### DIFF
--- a/EmacsModelines.py
+++ b/EmacsModelines.py
@@ -57,10 +57,12 @@ class EmacsModelinesListener(sublime_plugin.EventListener):
         if hasattr(sublime, 'find_resources'):
             for f in sublime.find_resources("*.tmLanguage"):
                 yield f
+            for f in sublime.find_resources("*.sublime-syntax"):
+                yield f
         else:
             for root, dirs, files in os.walk(sublime.packages_path()):
                 for f in files:
-                    if f.endswith(".tmLanguage"):
+                    if f.endswith(".tmLanguage") or f.endswith("*.sublime-syntax"):
                         langfile = os.path.relpath(os.path.join(root, f), sublime.packages_path())
                         # ST2 (as of build 2181) requires unix/MSYS style paths for the 'syntax' view setting
                         yield os.path.join('Packages', langfile).replace("\\", "/")


### PR DESCRIPTION
Sometime [back in June 2015](https://github.com/sublimehq/Packages/commit/585e986e926be96c1d1bd886497cc0f409097c51), some of the language syntax files for Sublime Text 3 were converted from `*.tmLanguage` to `*.sublime-syntax` (for example, `Erlang.tmLanguage` became `Erlang.sublime-syntax`), which made this package much less useful to me straight out of the box.  All of the languages that now used the `*.sublime-syntax` files had to be added to `EmacsModelines.sublime-settings` manually for it to continue functioning like before.

This pull request adds a search for `*.sublime-syntax` files in addition to `*.tmLanguage`, while preferring the former over the latter in ST3.