### PR TITLE
Remove workaround now that Bash is 1st-class in ST

### DIFF
--- a/EmacsModelines.sublime-settings
+++ b/EmacsModelines.sublime-settings
@@ -1,11 +1,9 @@
 {
   // Built-in mode mappings
-  "mode_mappings" : {
-    "bash": "Shell-Unix-Generic"
+  "mode_mappings": {
   },
 
   // User-added mode mappings
-  "user_mode_mappings" : {
+  "user_mode_mappings": {
   }
-
 }


### PR DESCRIPTION
Hi there - thanks for the cool package.

About a year ago, [Bash was added as a first-class syntax to Sublime](https://github.com/sublimehq/Packages/commit/660878eb8cde290ff49e7f41c2bd7432ee284f6e). This means that `-*- mode: bash -*-` can now work normally without any mapping onto `Shell-Unix-Generic`.

That mapping actually becomes a problem. For example, if a Sublime Build System is defined for Bash (like running [shellcheck](https://github.com/koalaman/shellcheck)), that Build System is not offered in a modeline'd file, like it is in a non-modeline'd `.bash` or `.sh` file.